### PR TITLE
A few changes for serverside framework integration and a usability fix

### DIFF
--- a/js/jquery.raty.js
+++ b/js/jquery.raty.js
@@ -65,7 +65,7 @@
 				}
 
 				self.stars = $this.children('img:not(".raty-cancel")');
-				self.score = $('<input />', { type: 'hidden', name: self.opt.scoreName }).appendTo(self);
+				self.score = $('<input />', { type: 'hidden', name: self.opt.scoreName, id: self.opt.scoreName  }).appendTo(self);
 
 				if (self.opt.score && self.opt.score > 0) {
 					self.score.val(self.opt.score);


### PR DESCRIPTION
Usability fix: removed cursor:pointer from div, added it to star images.
This prevents "false clicks" where the user hovers their mouse in between a star image and clicks, but nothing happens.

Framework integration changes make javascript form validation easier in serverside frameworks which should only be aware of the input field, not the generated div.
