### PR TITLE
Rename the HTML5 data attribute that settings are stored in to be more specific

### DIFF
--- a/js/jquery.raty.js
+++ b/js/jquery.raty.js
@@ -30,7 +30,7 @@
 	
 				self.opt = $.extend(true, {}, $.fn.raty.defaults, settings);
 
-				$this.data('settings', self.opt);
+				$this.data('raty-settings', self.opt);
 
 				if (typeof self.opt.number == 'function') {
 					self.opt.number = self.opt.number.call(self);
@@ -332,7 +332,7 @@
 		}, set: function(settings) {
 			this.each(function() {
 				var $this	= $(this),
-					actual	= $this.data('settings'),
+					actual	= $this.data('raty-settings'),
 					clone	= $this.clone().removeAttr('style').insertBefore($this);
 
 				$this.remove();


### PR DESCRIPTION
Rename the HTML5 data attribute that settings are stored in to be more specific

The previous data attribute ("settings"), is vague and could easily collide with other plugins or the user's JavaScript.

The new data attribute ("raty-settings") is specific to this plugin, and is unlikely to collide with other plugins or the user's JavaScript.
