### PR TITLE
Add the get() function, to get the value of any raty setting.

### DIFF
--- a/js/jquery.raty.js
+++ b/js/jquery.raty.js
@@ -329,6 +329,8 @@
 			}															// Full down: [x.00 .. x.25]
 		}, score: function() {
 			return arguments.length ? methods.setScore.apply(this, arguments) : methods.getScore.call(this);
+    }, get: function(property) {
+      return $(this).data('raty-settings')[property];
 		}, set: function(settings) {
 			this.each(function() {
 				var $this	= $(this),


### PR DESCRIPTION
Add the get() function, to get the value of any raty setting.

Usage:
$("#rating").raty("get", "number");

---

Note: This pull request is based off my previous pull request (#51), which changes the HTML5 data attribute from "settings" to "raty-settings".
