### PR TITLE
Amending the functionality to support readOnly custom messages on title elements.

### DIFF
--- a/lib/jquery.raty.js
+++ b/lib/jquery.raty.js
@@ -265,17 +265,31 @@
       var hint = this.opt.hints[score - 1];
       return (hint === '') ? '' : (hint || score);
     }, _lock: function() {
-      var score = parseInt(this.score.val(), 10), // TODO: 3.1 >> [['1'], ['2'], ['3', '.1', '.2']]
-          hint  = score ? methods._getHint.call(this, score) : this.opt.noRatedMsg;
-
-      $(this).data('readonly', true).css('cursor', '').attr('title', hint);
+      var score = parseInt(this.score.val(), 10); // TODO: 3.1 >> [['1'], ['2'], ['3', '.1', '.2']]
+      if (!score) {
+    	  hint = this.opt.noRatedMsg;
+      } else {
+    	  hint = methods._getHint.call(this, score);
+    	  if (hint === '') {
+    		  hint = this.score.val();
+    	  }
+      }
+      var title = methods._targetTextFormat.call(this, hint);
+      
+      $(this).data('readonly', true).css('cursor', '').attr('title', title);
 
       this.score.attr('readonly', 'readonly');
-      this.stars.attr('title', hint);
+      this.stars.attr('title', title);
 
       if (this.cancel) {
         this.cancel.hide();
       }
+    },  _targetTextFormat: function(hint) {
+    	if (this.opt.targetText) {
+    		return this.opt.targetText.replace('{score}', hint);
+    	} else {
+    		return hint;
+    	}
     }, _roundStars: function(score) {
       var rest = (score - Math.floor(score)).toFixed(2);
 


### PR DESCRIPTION
I need to display custom message with precision value of rating on hover/title so I've made a quick hack to do that as I haven't found any other way to do so. Below is config I use, the example can be found on http://www.librarist.com/us/book/9781477246825/.

BTW I've definitely broken some other functionality (at least the non-rated yet message is now affected so take this just as half-baked idea please and feel free to re-factor.

var ratyConfig = {
    hints: [ '', '', '', '', '' ],
    readOnly: true,
    path: '/resources/img',
    targetText: 'The average rating is {score} - click for more details',
    score: function() {
        return $(this).attr('data-score');
    }
};
