### PR TITLE
Fixing usage of undefined variable in _callback

### DIFF
--- a/lib/jquery.raty.js
+++ b/lib/jquery.raty.js
@@ -194,7 +194,7 @@
         }
       });
     }, _callback: function(options) {
-      for (i in options) {
+      for (var i in options) {
         if (typeof this.opt[options[i]] === 'function') {
           this.opt[options[i]] = this.opt[options[i]].call(this);
         }


### PR DESCRIPTION
Hello,

the variable `i` used in `_callback` function is currently undefined and so it will be interpreted as the property of `window`. I suggest to fix it.

Best regards
Oleg
