### PR TITLE
Fix hints for half-star #40

### DIFF
--- a/lib/jquery.raty.js
+++ b/lib/jquery.raty.js
@@ -293,6 +293,7 @@
         }
 
         var mouseover = evt && evt.type == 'mouseover';
+        var mousemove = evt && evt.type == 'mousemove';
 
         if (score === undefined) {
           score = this.opt.targetText;
@@ -305,7 +306,7 @@
             score = parseFloat(score).toFixed(1);
           }
 
-          if (!mouseover && !this.opt.targetKeep) {
+          if (!mouseover && !mousemove && !this.opt.targetKeep) {
             score = this.opt.targetText;
           }
         }


### PR DESCRIPTION
When half-stars are enabled and target is defined, the score name (hint) not appears in target element.
