### PR TITLE
Path as callback fix

### DIFF
--- a/lib/jquery.raty.js
+++ b/lib/jquery.raty.js
@@ -59,7 +59,7 @@
     },
 
     _adjustCallback: function() {
-      var options = ['number', 'readOnly', 'score', 'scoreName', 'target'];
+      var options = ['number', 'readOnly', 'score', 'scoreName', 'target', 'path'];
 
       for (var i = 0; i < options.length; i++) {
         if (typeof this.opt[options[i]] === 'function') {


### PR DESCRIPTION
Currently in the docs you specify that you may do a callback for the path, example:

``` html
<div id="rate" data-path="assets/raty/"></div>
```

``` js
$('#rate').raty({
    path : function() {
        return $(this).data('path');
    }
});
```

This however currently does not work. It creates this error `TypeError: this.opt.path.charAt is not a function` because its expecting a string but its instead a function.

This pull request simply adds `path` to your `_adjustCallback` method and all works as it should.
