### PR TITLE
Default score value to score field added

### DIFF
--- a/lib/jquery.raty.js
+++ b/lib/jquery.raty.js
@@ -284,7 +284,7 @@
     },
 
     _buildScoreField: function() {
-      return $('<input />', { name: this.opt.scoreName, type: 'hidden' }).appendTo(this);
+      return $('<input />', { name: this.opt.scoreName, type: 'hidden', value : this.opt.score }).appendTo(this);
     },
 
     _createCancel: function() {


### PR DESCRIPTION
Without this I had unexpected behaviour. By default was set score to 0, but when was triggered mouseleave event, score was set to 2.5. 
