### PR TITLE
Fix Half Star Issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
+.idea
 bower_components
 node_modules

--- a/lib/jquery.raty.js
+++ b/lib/jquery.raty.js
@@ -411,7 +411,7 @@
 
       var
         decimal = methods._getFirstDecimal.call(this, score),
-        integer = Math.ceil(score),
+        integer = Math.ceil(Math.abs(score)),
         group   = this.opt.hints[(integer || 1) - 1],
         hint    = group,
         set     = !evt || this.move;
@@ -498,7 +498,7 @@
       if (name) {
         var
           icon = this.opt[name],
-          star = this.stars[Math.ceil(score) - 1];
+          star = this.stars[Math.ceil(Math.abs(score)) - 1];
 
         methods._setIcon.call(this, star, icon);
       }                                                         // Full down: [x.00 .. x.25]
@@ -523,7 +523,7 @@
     _setTitle: function(score, evt) {
       if (score) {
         var
-          integer = parseInt(Math.ceil(score), 10),
+          integer = parseInt(Math.ceil(Math.abs(score)), 10),
           star    = this.stars[integer - 1];
 
         star.title = methods._getHint.call(this, score, evt);


### PR DESCRIPTION
If you set the `half` option to `true` and hover the 1st star at very left edge, you'll end up and litte error message in Dev Console. 

This error was cause by negative number of `score` value. The simple solution is to use [Math.abs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/abs) function.

![half](https://cloud.githubusercontent.com/assets/534610/5512675/2ca016f6-87f9-11e4-9e65-a375a9a8ed44.jpg)

Plus I added `.idea` directory for those, who use PHPStorm or WebStorm as their IDE to ignore all project specific files. 