### PR TITLE
Fix mouse over edge bug

### DIFF
--- a/lib/jquery.raty.js
+++ b/lib/jquery.raty.js
@@ -59,7 +59,7 @@
     },
 
     _adjustCallback: function() {
-      var options = ['number', 'readOnly', 'score', 'scoreName', 'target', 'path'];
+      var options = ['number', 'readOnly', 'score', 'scoreName', 'target'];
 
       for (var i = 0; i < options.length; i++) {
         if (typeof this.opt[options[i]] === 'function') {
@@ -499,8 +499,9 @@
         var
           icon = this.opt[name],
           star = this.stars[Math.ceil(score) - 1];
-
-        methods._setIcon.call(this, star, icon);
+          if (icon && star){
+            methods._setIcon.call(this, star, icon);
+          }
       }                                                         // Full down: [x.00 .. x.25]
     },
 
@@ -525,8 +526,9 @@
         var
           integer = parseInt(Math.ceil(score), 10),
           star    = this.stars[integer - 1];
-
-        star.title = methods._getHint.call(this, score, evt);
+          if (integer && star){
+            star.title = methods._getHint.call(this, score, evt);
+          }
       }
     },
 


### PR DESCRIPTION
When Half Star is true hovering past the first star will raise an error due to no star being targeted.  Checking if we have a star and icon fixes this issue.