### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,5 +12,4 @@
   "license"      : "MIT",
   "main"         : "lib/jquery.raty.js",
   "name"         : "raty",
-  "version"      : "2.7.0"
 }


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property
