### PR TITLE
 fix readOnly when raty is using fonts

### DIFF
--- a/lib/jquery.raty.js
+++ b/lib/jquery.raty.js
@@ -669,7 +669,7 @@
 
         if (self.data('readonly') !== readonly) {
           if (readonly) {
-            self.off('.raty').children('img').off('.raty');
+            self.off('.raty').children(this.opt.starType).off('.raty');
 
             methods._lock.call(this);
           } else {


### PR DESCRIPTION
Using fonts to write stars, when you want to change state to readOnly `$('div').raty('readOnly', true);`, it does not take into account that the children elements can be i tag, only with img tag `self.off('.raty').children('img').off('.raty');`, so I have replaced for `self.off('.raty').children(this.opt.starType).off('.raty');`