### PR TITLE
Click callback receive rounded score if half is true.

### DIFF
--- a/lib/jquery.raty.js
+++ b/lib/jquery.raty.js
@@ -181,15 +181,15 @@
           execute = true,
           score   = (that.opt.half || that.opt.precision) ? that.self.data('score') : (this.alt || $(this).data('alt'));
 
+        if (that.opt.half && !that.opt.precision) {
+            score = methods._roundHalfScore.call(that, score);
+          }
+
         if (that.opt.click) {
           execute = that.opt.click.call(that, +score, evt);
         }
 
         if (execute || execute === undefined) {
-          if (that.opt.half && !that.opt.precision) {
-            score = methods._roundHalfScore.call(that, score);
-          }
-
           methods._apply.call(that, +score);
         }
       });

--- a/spec/half_spec.js
+++ b/spec/half_spec.js
@@ -76,6 +76,21 @@ describe('#half', function() {
           // then
           expect(this.el.children('input').val()).toEqual('1.5');
         });
+
+        it ('gives a callback the rounded value', function() {
+          // given
+          this.el.raty({
+            half     : true,
+            halfShow : true,
+            click    : function(score) {
+              // then
+              expect(score).toEqual(1.5);
+            }
+          });
+
+          // when
+          Helper.click(this.el, 1, 5);
+        });
       });
 
       context('into round area', function() {
@@ -91,6 +106,21 @@ describe('#half', function() {
 
           // then
           expect(this.el.children('input').val()).toEqual('2');
+        });
+
+        it ('gives a callback the rounded value', function() {
+          // given
+          this.el.raty({
+            half:     true,
+            halfShow: true,
+            click: function(score) {
+              // then
+              expect(score).toEqual(2);
+            }
+          });
+
+          // when
+          Helper.click(this.el, 1, 9);
         });
       });
 


### PR DESCRIPTION
Currently, click callback receive unrounded value. This PR fix this issue.

In click callback, neither callback's argument nor `$(this).raty('score')` can give correct score
because both caluculate score after callback is invoked.