### PR TITLE
fix bug in _roundStars method

### DIFF
--- a/lib/jquery.raty.js
+++ b/lib/jquery.raty.js
@@ -481,6 +481,8 @@
     },
 
     _roundStars: function(score, evt) {
+      if(Number.isInteger(score))
+        score += 0.0001;
       var
         decimal = (score % 1).toFixed(2),
         name ;


### PR DESCRIPTION
Fix bug, when score is integer . 
`Math.ceil(score) - 1` make 2 from 3 and so on. 
If we add 0.0001 to scroe if it integer will solve the problem.
