### PR TITLE
Fix error when opt.half == true

### DIFF
--- a/src/raty.js
+++ b/src/raty.js
@@ -560,7 +560,7 @@ class Raty {
 
     if (this.opt.half) {
       const size = this._getWidth();
-      const percent = parseFloat((evt.pageX - icon.offsetLeft) / size);
+      const percent = parseFloat((evt.pageX - icon.getBoundingClientRect().x) / size);
 
       score = score - 1 + percent;
     }


### PR DESCRIPTION
When there is a space to the left of an element in Raty, incorrect coordinates are returned, resulting in an error.
https://codepen.io/fono0c/pen/MWBBjEP
![image](https://user-images.githubusercontent.com/6201749/215314545-9593c765-0dba-4839-b19f-7a1c223b4b7b.png)


This patch corrects the process of getting the coordinates of the element.

See below:
HTMLElement.offsetLeft: https://developer.mozilla.org/ja/docs/Web/API/HTMLElement/offsetLeft
Element.getBoundingClientRect: https://developer.mozilla.org/ja/docs/Web/API/Element/getBoundingClientRect
MouseEvent.pageX: 
https://developer.mozilla.org/ja/docs/Web/API/MouseEvent/pageX
